### PR TITLE
Fix mismatched dimensions in startGame

### DIFF
--- a/DiceSplitter/View/ContentView.swift
+++ b/DiceSplitter/View/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
     private func startGame() {
         let width = max(3, Int(mapSize.width))
         let height = max(3, Int(mapSize.height))
-        game = Game(rows: width, columns: height, playerType: playerType, numberOfPlayers: numberOfPlayers)
+        game = Game(rows: height, columns: width, playerType: playerType, numberOfPlayers: numberOfPlayers)
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure ContentView passes rows and columns in the correct order when starting a game

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6840ede0604c83258c50d082118788bc