### PR TITLE
Fix statistics persistence

### DIFF
--- a/DiceSplitter/View/ContentView.swift
+++ b/DiceSplitter/View/ContentView.swift
@@ -16,13 +16,17 @@ struct ContentView: View {
     @State private var numberOfPlayers = 3
     @State private var aiDifficulty: AIDifficulty = .medium
     @Query private var stats: [Statistics]
-    
+    @Environment(\.modelContext) private var modelContext
+
     private var stat: Statistics {
         // Get or create statistics
         if let existingStats = stats.first {
             return existingStats
         }
-        return Statistics()
+        let newStats = Statistics()
+        modelContext.insert(newStats)
+        try? modelContext.save()
+        return newStats
     }
     var body: some View {
 #if os(macOS)

--- a/DiceSplitter/View/GameView.swift
+++ b/DiceSplitter/View/GameView.swift
@@ -21,6 +21,7 @@ struct GameView: View {
     let resetGame: () -> Void
     
     @Environment(Audio.self) private var audio
+    @Environment(\.modelContext) private var modelContext
     let stats: Statistics
     
     var body: some View {
@@ -182,6 +183,7 @@ struct GameView: View {
                                     moves: game.totalMoves,
                                     difficulty: aiDifficulty
                                 )
+                                try? modelContext.save()
                                 
                                 if game.winner == game.activePlayer {
                                     audio.playSound(.win)

--- a/DiceSplitter/View/StatisticsView.swift
+++ b/DiceSplitter/View/StatisticsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct StatisticsView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
     let stats: Statistics
     @State private var selectedTab = 0
     
@@ -50,6 +51,7 @@ struct StatisticsView: View {
                     Menu {
                         Button("Reset Statistics", role: .destructive) {
                             stats.resetStatistics()
+                            try? modelContext.save()
                         }
                     } label: {
                         Image(systemName: "ellipsis.circle")


### PR DESCRIPTION
## Summary
- ensure a Statistics model is inserted into the SwiftData context
- save statistics whenever games end or stats are reset

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684202409fd4832591351660066dd21e